### PR TITLE
openapi2proto: init at 0.2.2

### DIFF
--- a/pkgs/by-name/op/openapi2proto/package.nix
+++ b/pkgs/by-name/op/openapi2proto/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "openapi2proto";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "NYTimes";
+    repo = "openapi2proto";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-1F0dBHTi4zlojTLZdv5MwNNlrzG4ryxAHMmOfSRSb0w=";
+  };
+
+  vendorHash = "sha256-qsef0ZYxDaVihhybKaaegs9enJqFA4e+N2zk7AcDgV4=";
+
+  subPackages = [ "cmd/openapi2proto" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = with lib; {
+    description = "A tool for generating Protobuf v3 schema and gRPC service definitions from OpenAPI/Swagger specifications.";
+    homepage = "https://github.com/NYTimes/openapi2proto";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ connerohnesorge ];
+    mainProgram = "openapi2proto";
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR adds a new package `openapi2proto` version 0.2.2 to nixpkgs. openapi2proto is a tool for generating Protobuf v3 schema and gRPC service definitions from OpenAPI/Swagger specifications, developed by The New York Times.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - N/A - Linux platform
- [x] Tested, as applicable:
  - [x] Tested compilation of the package
  - [x] Tested execution of the application
  - [x] Tested basic functionality (help command works correctly)
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/tree/master/nixos/tests))
  - N/A - No specific NixOS tests for CLI tools like this
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - No dependencies detected - this is a new standalone package
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] 25.05 Release Notes (or backporting 24.11 and 24.05 Release notes)
  - [x] (For new packages) Added a release notes entry if the change is significant or affects many users
  - N/A - New package addition, will be included automatically in release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/manual/nix/stable/command-ref/conf-file.html) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/manual/nix/stable/command-ref/conf-file.html) on non-NixOS linux)

## Technical Details

- **Package type**: Go application using `buildGoModule`
- **Location**: `pkgs/by-name/op/openapi2proto/package.nix` (following by-name conventions)
- **License**: Apache Software License 2.0
- **Upstream**: https://github.com/NYTimes/openapi2proto
- **Maintainer**: @connerohnesorge
- **Binary tested**: `openapi2proto --help` executes correctly and shows usage information

## Validation

- Package builds successfully in sandbox: ✅
- Binary executes without errors: ✅
- Package follows nixpkgs conventions: ✅
- Proper metadata and licensing: ✅

🤖 Generated with [Claude Code](https://claude.ai/code)