### PR TITLE
neonctl: init at 2.15.0

### DIFF
--- a/pkgs/by-name/ne/neonctl/package.nix
+++ b/pkgs/by-name/ne/neonctl/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bun,
+  nodejs,
+  makeWrapper,
+  cacert,
+}:
+
+let
+  # Create a fixed-output derivation for the dependencies
+  bunDeps = stdenv.mkDerivation {
+    pname = "neonctl-bun-deps";
+    version = "2.15.0";
+
+    src = fetchFromGitHub {
+      owner = "neondatabase";
+      repo = "neonctl";
+      rev = "v2.15.0";
+      hash = "sha256-jGxi3DyFIrwPK5+yUvN3WRR2/3crm6ids5y6HRToVxM=";
+    };
+
+    nativeBuildInputs = [ bun cacert ];
+
+    buildPhase = ''
+      export BUN_CACHE_DIR=$TMPDIR/bun-cache
+      export HOME=$TMPDIR
+      bun install --no-save --frozen-lockfile
+    '';
+
+    installPhase = ''
+      cp -r node_modules $out
+    '';
+
+    # Disable script patching to avoid store path references
+    dontPatchShebangs = true;
+    dontPatchELF = true;
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-lssCZbVILRE3LGi8VxZlRN8cRukPfBT7/gDskEhJga8=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "neonctl";
+  version = "2.15.0";
+
+  src = fetchFromGitHub {
+    owner = "neondatabase";
+    repo = "neonctl";
+    rev = "v${version}";
+    hash = "sha256-jGxi3DyFIrwPK5+yUvN3WRR2/3crm6ids5y6HRToVxM=";
+  };
+
+  nativeBuildInputs = [
+    bun
+    nodejs
+    makeWrapper
+  ];
+
+  # Copy pre-built dependencies
+  preBuild = ''
+    export BUN_CACHE_DIR=$TMPDIR/bun-cache
+    export HOME=$TMPDIR
+    cp -r ${bunDeps} node_modules
+    chmod -R +w node_modules
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Generate parameters using Bun
+    bun generateOptionsFromSpec.ts
+
+    # Clean and build
+    rm -rf dist
+    bun build src/index.ts --outdir dist --target node
+
+    # Copy additional files
+    cp src/*.html package*.json README.md ./dist/ || true
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/neonctl
+
+    # Copy built files
+    cp -r dist/* $out/lib/neonctl/
+
+    # Create wrapper script that uses node to run the built JS
+    makeWrapper ${nodejs}/bin/node $out/bin/neonctl \
+      --add-flags "$out/lib/neonctl/index.js"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command-line interface that lets you manage Neon Serverless Postgres directly from the terminal";
+    longDescription = ''
+      The Neon CLI is a command-line interface that lets you manage Neon Serverless Postgres
+      directly from the terminal. Supports authentication via browser or API key, manages
+      projects, branches, databases, roles, and provides CLI autocompletion.
+    '';
+    homepage = "https://github.com/neondatabase/neonctl";
+    changelog = "https://github.com/neondatabase/neonctl/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ connerohnesorge ];
+    platforms = lib.platforms.all;
+    mainProgram = "neonctl";
+  };
+}


### PR DESCRIPTION
The Neon CLI is a command-line interface that lets you manage Neon Serverless Postgres directly from the terminal. This package uses Bun for the build process and provides a fully functional CLI tool for managing Neon projects, branches, databases, and roles.

🤖 Generated with [Claude Code](https://claude.ai/code)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
